### PR TITLE
Fix db error reporting

### DIFF
--- a/services/metadata_service/api/artifact.py
+++ b/services/metadata_service/api/artifact.py
@@ -137,7 +137,7 @@ class ArtificatsApi(object):
         )
 
         filtered_body = ArtificatsApi._filter_artifacts_by_attempt_id(
-            artifacts.body)
+            artifacts)
         return web.Response(
             status=artifacts.response_code, body=json.dumps(filtered_body)
         )
@@ -181,7 +181,7 @@ class ArtificatsApi(object):
         )
 
         filtered_body = ArtificatsApi._filter_artifacts_by_attempt_id(
-            artifacts.body)
+            artifacts)
         return web.Response(
             status=artifacts.response_code, body=json.dumps(filtered_body)
         )
@@ -216,7 +216,7 @@ class ArtificatsApi(object):
 
         artifacts = await self._async_table.get_artifacts_in_runs(flow_name, run_number)
         filtered_body = ArtificatsApi._filter_artifacts_by_attempt_id(
-            artifacts.body)
+            artifacts)
         return web.Response(
             status=artifacts.response_code, body=json.dumps(filtered_body)
         )
@@ -352,9 +352,11 @@ class ArtificatsApi(object):
 
     @staticmethod
     def _filter_artifacts_by_attempt_id(artifacts):
-        attempt_id = ArtificatsApi._get_latest_attempt_id(artifacts)
+        if artifacts.response_code != 200:
+            return artifacts.body
+        attempt_id = ArtificatsApi._get_latest_attempt_id(artifacts.body)
         result = []
-        for artifact in artifacts:
+        for artifact in artifacts.body:
             if artifact['attempt_id'] == attempt_id:
                 result.append(artifact)
 

--- a/services/metadata_service/api/artifact.py
+++ b/services/metadata_service/api/artifact.py
@@ -136,13 +136,10 @@ class ArtificatsApi(object):
             flow_name, run_number, step_name, task_id
         )
 
-        if artifacts.response_code == 200:
-            body = ArtificatsApi._filter_artifacts_by_attempt_id(
-                artifacts.body)
-        else:
-            body = artifacts.body
+        filtered_body = ArtificatsApi._filter_artifacts_by_attempt_id(
+            artifacts.body)
         return web.Response(
-            status=artifacts.response_code, body=json.dumps(body)
+            status=artifacts.response_code, body=json.dumps(filtered_body)
         )
 
     async def get_artifacts_by_step(self, request):
@@ -183,13 +180,10 @@ class ArtificatsApi(object):
             flow_name, run_number, step_name
         )
 
-        if artifacts.response_code == 200:
-            body = ArtificatsApi._filter_artifacts_by_attempt_id(
-                artifacts.body)
-        else:
-            body = artifacts.body
+        filtered_body = ArtificatsApi._filter_artifacts_by_attempt_id(
+            artifacts.body)
         return web.Response(
-            status=artifacts.response_code, body=json.dumps(body)
+            status=artifacts.response_code, body=json.dumps(filtered_body)
         )
 
     async def get_artifacts_by_run(self, request):
@@ -221,13 +215,10 @@ class ArtificatsApi(object):
         run_number = request.match_info.get("run_number")
 
         artifacts = await self._async_table.get_artifacts_in_runs(flow_name, run_number)
-        if artifacts.response_code == 200:
-            body = ArtificatsApi._filter_artifacts_by_attempt_id(
-                artifacts.body)
-        else:
-            body = artifacts.body
+        filtered_body = ArtificatsApi._filter_artifacts_by_attempt_id(
+            artifacts.body)
         return web.Response(
-            status=artifacts.response_code, body=json.dumps(body)
+            status=artifacts.response_code, body=json.dumps(filtered_body)
         )
 
     async def create_artifacts(self, request):

--- a/services/metadata_service/api/artifact.py
+++ b/services/metadata_service/api/artifact.py
@@ -136,10 +136,13 @@ class ArtificatsApi(object):
             flow_name, run_number, step_name, task_id
         )
 
-        filtered_body = ArtificatsApi._filter_artifacts_by_attempt_id(
-            artifacts.body)
+        if artifacts.response_code == 200:
+            body = ArtificatsApi._filter_artifacts_by_attempt_id(
+                artifacts.body)
+        else:
+            body = artifacts.body
         return web.Response(
-            status=artifacts.response_code, body=json.dumps(filtered_body)
+            status=artifacts.response_code, body=json.dumps(body)
         )
 
     async def get_artifacts_by_step(self, request):
@@ -180,10 +183,13 @@ class ArtificatsApi(object):
             flow_name, run_number, step_name
         )
 
-        filtered_body = ArtificatsApi._filter_artifacts_by_attempt_id(
-            artifacts.body)
+        if artifacts.response_code == 200:
+            body = ArtificatsApi._filter_artifacts_by_attempt_id(
+                artifacts.body)
+        else:
+            body = artifacts.body
         return web.Response(
-            status=artifacts.response_code, body=json.dumps(filtered_body)
+            status=artifacts.response_code, body=json.dumps(body)
         )
 
     async def get_artifacts_by_run(self, request):
@@ -215,10 +221,13 @@ class ArtificatsApi(object):
         run_number = request.match_info.get("run_number")
 
         artifacts = await self._async_table.get_artifacts_in_runs(flow_name, run_number)
-        filtered_body = ArtificatsApi._filter_artifacts_by_attempt_id(
-            artifacts.body)
+        if artifacts.response_code == 200:
+            body = ArtificatsApi._filter_artifacts_by_attempt_id(
+                artifacts.body)
+        else:
+            body = artifacts.body
         return web.Response(
-            status=artifacts.response_code, body=json.dumps(filtered_body)
+            status=artifacts.response_code, body=json.dumps(body)
         )
 
     async def create_artifacts(self, request):


### PR DESCRIPTION
From what I can tell, this will fix the obfuscation of the error message contained in the `DBResponse.body`.

Some context, from Tim:

--- 

I'm trying to take a look at the artifacts associated with one of our SFN executions but when trying to call:

``` python
Step(...).task.data
```
We run into the following error:

```
ServiceException: Metadata request (/flows/{Flow}/runs/{Run}/steps/start/tasks/{Task}/artifacts) failed (code 500): 500 Internal Server Error
```
Looking at the logs from our metadata service, I see the following error:

```
Traceback (most recent call last):
    File "/opt/latest/lib/python3.7/site-packages/aiohttp/web_protocol.py", line 418, in start
        resp = await task
    File "/opt/latest/lib/python3.7/site-packages/aiohttp/web_app.py", line 458, in _handle
        resp = await handler(request)
    File "/opt/latest/lib/python3.7/site-packages/services/metadata_service/api/artifact.py", line 140, in get_artifacts_by_task
        artifacts.body)
    File "/opt/latest/lib/python3.7/site-packages/services/metadata_service/api/artifact.py", line 355, in _filter_artifacts_by_attempt_id
        attempt_id = ArtificatsApi._get_latest_attempt_id(artifacts)
    File "/opt/latest/lib/python3.7/site-packages/services/metadata_service/api/artifact.py", line 349, in _get_latest_attempt_id
        if artifact['attempt_id'] > attempt_id:
TypeError: string indices must be integers
```

From what I can tell, this can only occur when the result of this call: https://github.com/Netflix/metaflow-service/blob/b656d42cfb946b5ec64ef15b4f5e86a1505a4e90/services/data/postgres_async_db.py#L112-L156 returns a `DBResponse` object with a body of type string. And it looks like this would only happen in the case of error handling. Unfortunately it looks like the underlying error message is obfuscated by this error.

----